### PR TITLE
Add Support for a MONGO_CONN env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,12 +49,14 @@ All options and defaults are listed below
 * host: localhost
 * port: 27017
 * database: screeps
+* uri: mongodb://localhost:27017/screeps
+
+If the uri Parameter is supplied it will overwrite all other settings. Use it for Authentication, passing extra options, etc.
 
 ### Redis
 
 * host: localhost
 * port: 6379
-
 
 ## Examples
 
@@ -77,4 +79,5 @@ Please note that this method only works when launching modules directly, when la
 
 ```
 MONGO_HOST='192.168.0.222'
+MONGO_CONN='mongodb://username:password@hostname.com/database_name?ssl=true'
 ```

--- a/lib/common/_connect.js
+++ b/lib/common/_connect.js
@@ -12,14 +12,13 @@ module.exports = function (config) {
     if (exports._connected) {
       return q.when()
     }
-    let uri;
+    let uri
 
     if (config.mongo.uri) {
-      uri = config.mongo.uri;
+      uri = config.mongo.uri
     } else {
       uri = `mongodb://${config.mongo.host}:${config.mongo.port}/${config.mongo.database}`
     }
-    
     delete config.mongo.host
     delete config.mongo.port
     delete config.mongo.database

--- a/lib/common/_connect.js
+++ b/lib/common/_connect.js
@@ -12,8 +12,14 @@ module.exports = function (config) {
     if (exports._connected) {
       return q.when()
     }
+    let uri;
 
-    let uri = `mongodb://${config.mongo.host}:${config.mongo.port}/${config.mongo.database}`
+    if (config.mongo.uri) {
+      uri = config.mongo.uri;
+    } else {
+      uri = `mongodb://${config.mongo.host}:${config.mongo.port}/${config.mongo.database}`
+    }
+    
     delete config.mongo.host
     delete config.mongo.port
     delete config.mongo.database

--- a/lib/common/index.js
+++ b/lib/common/index.js
@@ -10,7 +10,7 @@ module.exports = function (config) {
     mongo: Object.assign({
       host: process.env.MONGO_HOST || 'localhost',
       port: process.env.MONGO_PORT || 27017,
-      database: process.env.MONGO_DATABASE || 'screeps', 
+      database: process.env.MONGO_DATABASE || 'screeps',
       uri: process.env.MONGO_CONN || ''   //  Pass complete Connection String in Env Variable (i.e. for authenticated connections)
     }, opts.mongo || {}),
     redis: Object.assign({

--- a/lib/common/index.js
+++ b/lib/common/index.js
@@ -10,7 +10,8 @@ module.exports = function (config) {
     mongo: Object.assign({
       host: process.env.MONGO_HOST || 'localhost',
       port: process.env.MONGO_PORT || 27017,
-      database: process.env.MONGO_DATABASE || 'screeps'
+      database: process.env.MONGO_DATABASE || 'screeps', 
+      uri: process.env.MONGO_CONN || ''   //  Pass complete Connection String in Env Variable (i.e. for authenticated connections)
     }, opts.mongo || {}),
     redis: Object.assign({
       host: process.env.REDIS_HOST || 'localhost',


### PR DESCRIPTION
For my Usecase I want to use an existing authenticated MongoDB. The current Version of screepsmod-mongo does not provide a good way to pass User/Password to the mongodb client. Thus the added support for passing the connection String as a whole in a MONGO_CONN envvar or via the .screepsrc File.

I would additionally propose to deprecate the old host, port and database parameters as they're not really good style (though I guess that's an opinion)