### PR TITLE
Update importDB and upgradeDB to support database version 9, fixes #29 (and #27)

### DIFF
--- a/lib/common/_connect.js
+++ b/lib/common/_connect.js
@@ -544,7 +544,7 @@ async function upgradeDB () {
 
     const ps = []
 
-    const rooms = await db['rooms'].find({})
+    const rooms = await db.rooms.find({})
     const activeRoomNames = []
 
     rooms.forEach(room => {
@@ -553,7 +553,7 @@ async function upgradeDB () {
         delete room.active
 
         const { _id, ...obj } = room
-        ps.push(db['rooms'].update({ _id }, obj))
+        ps.push(db.rooms.update({ _id }, obj))
       }
     })
 

--- a/lib/common/_connect.js
+++ b/lib/common/_connect.js
@@ -288,10 +288,12 @@ exports.importDB = async function importDB (path = './db.json') {
               const v = row.data[k]
               const type = k.slice(0, k.indexOf(':') + 1)
               const hashTypes = [env.keys.MEMORY_SEGMENTS, env.keys.ROOM_HISTORY, env.keys.ROOM_EVENT_LOG]
-              if (hashTypes.indexOf(type) !== -1) {
+              if (hashTypes.includes(type)) {
                 for (const kk in v) {
                   ps.push(env.hmset(k, kk, typeof v[kk] === 'object' ? JSON.stringify(v[kk]) : v[kk]))
                 }
+              } else if (k === env.keys.ACTIVE_ROOMS) {
+                ps.push(env.sadd(env.keys.ACTIVE_ROOMS, v))
               } else {
                 ps.push(env.set(k, typeof v === 'object' ? JSON.stringify(v) : v))
               }

--- a/lib/common/_connect.js
+++ b/lib/common/_connect.js
@@ -538,7 +538,7 @@ async function upgradeDB () {
     })
     await Promise.all(ps)
   }
-  
+
   if (version < 9) {
     console.log('Applying version 9')
 

--- a/lib/common/_connect.js
+++ b/lib/common/_connect.js
@@ -4,7 +4,7 @@ const { MongoClient, ObjectId } = require('mongodb')
 const Redis = require('redis')
 const fs = require('fs')
 
-const DATABASE_VERSION = 8
+const DATABASE_VERSION = 9
 
 let C
 
@@ -369,7 +369,7 @@ async function upgradeDB () {
     await db['rooms.objects'].remove({ type: 'powerCreep', ageTime: { $lt: time } })
   }
 
-  if (version < 4 && DATABASE_VERSION >= 4) { // Factories update
+  if (version < 4) { // Factories update
     console.log('Applying version 4')
     const depositTypes = [C.RESOURCE_SILICON, C.RESOURCE_METAL, C.RESOURCE_BIOMASS, C.RESOURCE_MIST]
     const busRooms = await db.rooms.find({ $or: [{ _id: { $regex: /^[WE]\d*0[NS]/ } }, { _id: { $regex: /0$/ } }] })
@@ -384,7 +384,7 @@ async function upgradeDB () {
     await Promise.all(ps)
   }
 
-  if (version < 5 && DATABASE_VERSION >= 5) { // Store update
+  if (version < 5) { // Store update
     console.log('Applying version 5')
     const ps = []
     const energyOnly = function energyOnly (structure) {
@@ -533,8 +533,34 @@ async function upgradeDB () {
       console.log(`${object.type}#${object._id}: ${JSON.stringify(object.spawning, 0, 2)}`)
       object.spawning.spawnTime = gameTime + object.spawning.remainingTime
       delete object.spawning.remainingTime
-      return db['rooms.objects'].update(object)
+      const { _id, ...obj } = object
+      return db['rooms.objects'].update({ _id }, obj)
     })
+    await Promise.all(ps)
+  }
+  
+  if (version < 9) {
+    console.log('Applying version 9')
+
+    const ps = []
+
+    const rooms = await db['rooms'].find({})
+    const activeRoomNames = []
+
+    rooms.forEach(room => {
+      if (room.active) {
+        activeRoomNames.push(room._id)
+        delete room.active
+
+        const { _id, ...obj } = room
+        ps.push(db['rooms'].update({ _id }, obj))
+      }
+    })
+
+    if (activeRoomNames[0]) {
+      ps.push(env.sadd(env.keys.ACTIVE_ROOMS, activeRoomNames))
+    }
+
     await Promise.all(ps)
   }
 


### PR DESCRIPTION
* Correctly store ACTIVE_ROOMS as a set instead of a string when importing env database
* Add database upgrade code for version 9, converted from official Screeps server upgrade code
* Fix issue with version 8 upgrade code

Tested with Screeps server version 4.2.10 and NodeJS 12