### PR TITLE
Add support for redis namespaces

### DIFF
--- a/lib/common/_connect.js
+++ b/lib/common/_connect.js
@@ -1,7 +1,7 @@
 const q = require('q')
 const EventEmitter = require('events').EventEmitter
 const { MongoClient, ObjectId } = require('mongodb')
-const Redis = require('redis')
+const Redis = require('ioredis')
 const fs = require('fs')
 
 const DATABASE_VERSION = 9
@@ -26,9 +26,14 @@ module.exports = function (config) {
     delete config.mongo.port
     delete config.mongo.database
 
-    const redis = Redis.createClient(config.redis)
-    const pub = Redis.createClient(config.redis)
-    const sub = Redis.createClient(config.redis)
+    if (config.redis.namespace) {
+      config.redis.keyPrefix = `${config.redis.namespace}:`
+      delete config.redis.namespace
+    }
+
+    const redis = new Redis(config.redis)
+    const pub = new Redis(config.redis)
+    const sub = new Redis(config.redis)
 
     const mongo = q.ninvoke(MongoClient, 'connect', uri, Object.assign({ promiseLibrary: Promise, useUnifiedTopology: true }, config.mongo))
       .then(client => client.db())
@@ -78,10 +83,10 @@ module.exports = function (config) {
                 if (v === '^[WE]d*5[NS]d*5$') {
                   query.$regex = v.replace(/\]d\*/g, ']\\d*')
 
-                // https://github.com/screeps/backend-local/blob/7520c8c7e6a443ad955d25e064dbd151a909d8cb/lib/cronjobs.js#L393
-                // https://github.com/screeps/backend-local/blob/7520c8c7e6a443ad955d25e064dbd151a909d8cb/lib/strongholds.js#L132
-                //
-                // ignore properly escaped sector regex queries
+                  // https://github.com/screeps/backend-local/blob/7520c8c7e6a443ad955d25e064dbd151a909d8cb/lib/cronjobs.js#L393
+                  // https://github.com/screeps/backend-local/blob/7520c8c7e6a443ad955d25e064dbd151a909d8cb/lib/strongholds.js#L132
+                  //
+                  // ignore properly escaped sector regex queries
                 } else if (v.match(/\^[EW]\d*\\d[NS]\d*\\d\$/g) === null && v.match(/\^\[[EW]{2}\]\\d\*5\[[NS]{2}\]\\d\*5\$/g) === null) {
                   // default regex escape fix for loki regex queries to work with mongo regex queries
                   query.$regex = v.replace(/\\{1,2}/g, '\\\\')

--- a/lib/common/index.js
+++ b/lib/common/index.js
@@ -15,7 +15,8 @@ module.exports = function (config) {
     }, opts.mongo || {}),
     redis: Object.assign({
       host: process.env.REDIS_HOST || 'localhost',
-      port: process.env.REDIS_PORT || 6379
+      port: process.env.REDIS_PORT || 6379,
+      namespace: process.env.REDIS_NAMESPACE || ''
     }, opts.redis || {})
   })
   config.common.storage.env.keys.ROOM_INTENTS = 'roomIntents:'

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "body-parser": "^1.19.0",
     "express": "^4.17.1",
     "ini": "^1.3.4",
+    "ioredis": "^4.28.5",
     "mongodb": "^3.5.5",
     "q-json-response": "^0.1.3",
     "redis": "^3.0.2"


### PR DESCRIPTION
Why?
---
I'm exploring running screeps in a distributed way and separating each instance while maintain a cluster deployed redis is super useful. I had made this fork for myself to enable prefixing the redis queries and it's worked fairly well. I thought I'd share it with the community

How?
---
Add a new dependency [ioredis](https://www.npmjs.com/package/ioredis) which has native `Redis` client class support while also adding some optimization and most importantly *key prefixing*

This allows a drop-in replacement which also honors a new configuration option `namespace` which is then translated to `${namespace}:` and saved to `redis.config.keyPrefix`. The remaining calls are natively compatible and had no known issues.