### PR TITLE
indexBy was renamed to keyBy in lodash 4

### DIFF
--- a/lib/backend/api/index.js
+++ b/lib/backend/api/index.js
@@ -39,7 +39,7 @@ module.exports = function (config) {
         return db.users.find({ _id: { $in: _.map(messages, '_id') } })
           .then(users => {
             users = users.map(i => _.pick(i, ['_id', 'username', 'badge']))
-            return { messages, users: _.indexBy(users, '_id') }
+            return { messages, users: _.keyBy(users, '_id') }
           })
       })
   }))


### PR DESCRIPTION
This fixes a server error when trying to get the user's messages:
```
screeps-1  | 2025-03-19T15:37:42.753679131Z [backend] TypeError: _.indexBy is not a function
screeps-1  | 2025-03-19T15:37:42.753700271Z     at db.users.find.then.users (/screeps/mods/node_modules/screepsmod-mongo/lib/backend/api/index.js:42:41)
screeps-1  | 2025-03-19T15:37:42.753712851Z     at _fulfilled (/screeps/mods/node_modules/q/q.js:854:54)
screeps-1  | 2025-03-19T15:37:42.753716771Z     at /screeps/mods/node_modules/q/q.js:883:30
screeps-1  | 2025-03-19T15:37:42.753720461Z     at Promise.promise.promiseDispatch (/screeps/mods/node_modules/q/q.js:816:13)
screeps-1  | 2025-03-19T15:37:42.753724421Z     at /screeps/mods/node_modules/q/q.js:624:44
screeps-1  | 2025-03-19T15:37:42.753728251Z     at runSingle (/screeps/mods/node_modules/q/q.js:137:13)
screeps-1  | 2025-03-19T15:37:42.753732031Z     at flush (/screeps/mods/node_modules/q/q.js:125:13)
screeps-1  | 2025-03-19T15:37:42.753735821Z     at process._tickCallback (internal/process/next_tick.js:61:11)
```