### PR TITLE
Fix patchLokiOps breaking if the passed regex isn't a string

### DIFF
--- a/lib/common/_connect.js
+++ b/lib/common/_connect.js
@@ -87,9 +87,11 @@ module.exports = function (config) {
                 // https://github.com/screeps/backend-local/blob/7520c8c7e6a443ad955d25e064dbd151a909d8cb/lib/strongholds.js#L132
                 //
                 // ignore properly escaped sector regex queries
-                } else if (v.match(/\^[EW]\d*\\d[NS]\d*\\d\$/g) === null && v.match(/\^\[[EW]{2}\]\\d\*5\[[NS]{2}\]\\d\*5\$/g) === null) {
+                } else if (typeof v === 'string' && v.match(/\^[EW]\d*\\d[NS]\d*\\d\$/g) === null && v.match(/\^\[[EW]{2}\]\\d\*5\[[NS]{2}\]\\d\*5\$/g) === null) {
                   // default regex escape fix for loki regex queries to work with mongo regex queries
                   query.$regex = v.replace(/\\{1,2}/g, '\\\\')
+                } else {
+                  query.$regex = v
                 }
               }
               if (typeof v === 'object') {


### PR DESCRIPTION
This fixes something like `storage.db['rooms'].find({ name: { $regex: /^[WE]\d*5[NS]\d*5$/ } })`, which would otherwise break with
```
Error: TypeError: v.match is not a function
    at patchLokiOps (/mods/screepsmod-mongo/lib/common/_connect.js:94:30)
```

Encountered that one while writing the portals mod and passing a regex object directly into find.