### PR TITLE
Defer the initialization of dbIndexes

### DIFF
--- a/lib/common/storage.js
+++ b/lib/common/storage.js
@@ -1,6 +1,6 @@
 module.exports = function (config) {
   const storage = config.common.storage
-  config.common.dbIndexes = {
+  const defaultIndexes = {
     users: { user: 1, username: 1, email: 1, active: 1, cpu: 1 },
     'users.code': { user: 1 },
     rooms: { active: 1, status: 1 },
@@ -14,6 +14,7 @@ module.exports = function (config) {
     'users.power_creeps': { user: 1 },
     'users.resources': { user: 1 }
   }
+  config.common.dbIndexes = Object.assign(config.common.dbIndexes || {}, defaultIndexes)
   if (!storage.env.keys.STATUS_DATA) {
     // Hotfix for server bug, to be removed once patched upstream
     storage.env.keys.STATUS_DATA = storage.env.keys.ROOM_STATUS_DATA


### PR DESCRIPTION
This lets mods that start before us define their mongo indices.

The use case being adding and api token table from screepsmod-auth, which is generally installed and loaded first.