### PR TITLE
Rework for recent Mongo versions

### DIFF
--- a/lib/backend/api/index.js
+++ b/lib/backend/api/index.js
@@ -1,10 +1,26 @@
 const crypto = require('crypto')
 const express = require('express')
 const bodyParser = require('body-parser')
-const jsonResponse = require('q-json-response')
 const auth = require('@screeps/backend/lib/game/api/auth')
 const authlib = require('@screeps/backend/lib/authlib')
 const _ = require('lodash')
+
+/** Same contract as legacy `q-json-response`: envelopes success as `{ ok: 1, ...data }`. */
+function jsonResponse (fn) {
+  return function (request, response, next) {
+    Promise.resolve()
+      .then(() => fn(request, response))
+      .then((data) => {
+        response.json(_.extend({ ok: 1 }, data))
+        next()
+      })
+      .catch((error) => {
+        response.json({ error: String(error) })
+        if (error.stack) console.error(error.stack)
+        next()
+      })
+  }
+}
 
 module.exports = function (config) {
   const { common } = config
@@ -44,7 +60,7 @@ module.exports = function (config) {
   router.post('/api/user/messages/mark-read', auth.tokenAuth, jsonResponse(async (request) => {
     const _id = request.body.id
     console.log(_id, request.user._id)
-    const message = db['users.messages'].findOne({ _id, user: request.user._id, type: 'in' })
+    const message = await db['users.messages'].findOne({ _id, user: request.user._id, type: 'in' })
     if (!message) {
       throw new Error('invalid id')
     }

--- a/lib/backend/api/index.js
+++ b/lib/backend/api/index.js
@@ -9,6 +9,7 @@ const _ = require('lodash')
 module.exports = function (config) {
   const { common } = config
   const { db, env, pubsub } = common.storage
+  // @ts-expect-error
   const router = new express.Router()
   config.backend.on('expressPreConfig', (app) => app.use(router))
   router.use(bodyParser.json({
@@ -27,96 +28,84 @@ module.exports = function (config) {
     await env.hmset(env.keys.ROOM_INTENTS + request.body.room, request.user._id.toString() + '.manual', JSON.stringify({ [request.body._id]: { [request.body.name]: request.body.intent } }))
     await db.rooms.update({ _id: request.body.room }, { $set: { active: true } })
   }))
-  router.get('/api/user/messages/index', auth.tokenAuth, jsonResponse((request) => {
-    return db['users.messages'].findEx({ user: request.user._id }, { sort: { date: -1 } })
-      .then(data => {
-        const messages = []
-        data.forEach(message => {
-          if (!messages.find(i => i._id === message.respondent)) {
-            messages.push({ _id: message.respondent, message })
-          }
-        })
-        return db.users.find({ _id: { $in: _.map(messages, '_id') } })
-          .then(users => {
-            users = users.map(i => _.pick(i, ['_id', 'username', 'badge']))
-            return { messages, users: _.keyBy(users, '_id') }
-          })
-      })
+
+  router.get('/api/user/messages/index', auth.tokenAuth, jsonResponse(async (request) => {
+    const data = await db['users.messages'].findEx({ user: request.user._id }, { sort: { date: -1 } })
+    const messages = []
+    data.forEach(message => {
+      if (!messages.find(i => i._id === message.respondent)) {
+        messages.push({ _id: message.respondent, message })
+      }
+    })
+    const users = await db.users.find({ _id: { $in: _.map(messages, '_id') } }, { username: true, badge: true })
+    return { messages, users: _.keyBy(users, '_id') }
   }))
-  router.post('/api/user/messages/mark-read', auth.tokenAuth, jsonResponse((request) => {
-    const _id = request.body.id; let message
+
+  router.post('/api/user/messages/mark-read', auth.tokenAuth, jsonResponse(async (request) => {
+    const _id = request.body.id
     console.log(_id, request.user._id)
-    return db['users.messages'].findOne({ _id, user: request.user._id, type: 'in' })
-      .then((_message) => {
-        if (!_message) {
-          return Promise.reject(new Error('invalid id'))
+    const message = db['users.messages'].findOne({ _id, user: request.user._id, type: 'in' })
+    if (!message) {
+      throw new Error('invalid id')
+    }
+    await db['users.messages'].update({ _id }, { $set: { unread: false } })
+    return Promise.all([
+      pubsub.publish(`user:${message.user}/message:${message.respondent}`, JSON.stringify({
+        message: {
+          _id: request.body.id,
+          unread: false
         }
-        message = _message
-        return db['users.messages'].update({ _id }, { $set: { unread: false } })
-      })
-      .then((data) => {
-        return Promise.all([
-          pubsub.publish(`user:${message.user}/message:${message.respondent}`, JSON.stringify({
-            message: {
-              _id: request.body.id,
-              unread: false
-            }
-          })),
-          pubsub.publish(`user:${message.respondent}/message:${message.user}`, JSON.stringify({
-            message: {
-              _id: message.outMessage,
-              unread: false
-            }
-          })),
-          db['users.messages'].update({ _id: message.outMessage }, { $set: { unread: false } })
-        ])
-      })
+      })),
+      pubsub.publish(`user:${message.respondent}/message:${message.user}`, JSON.stringify({
+        message: {
+          _id: message.outMessage,
+          unread: false
+        }
+      })),
+      db['users.messages'].update({ _id: message.outMessage }, { $set: { unread: false } })
+    ])
   }))
-  authlib.genToken = function (id) {
+
+  authlib.genToken = async function genToken (id) {
     const token = crypto.createHmac('sha1', 'hsdhweh342sdbj34e').update(new Date().getTime() + id).digest('hex')
-    return env.setex(`auth_${token}`, 300, id).then(() => token)
+    await env.setex(`auth_${token}`, 300, id)
+    return token
   }
 
-  authlib.checkToken = function (token, noConsume) {
+  authlib.checkToken = async function checkToken (token, noConsume) {
     const authKey = `auth_${token}`
 
-    return env.get(authKey)
-      .then((data) => {
-        if (!data) {
-          return Promise.reject(false) // eslint-disable-line prefer-promise-reject-errors
-        }
-        if (!noConsume) {
-          env.ttl(authKey)
-            .then((ttl) => {
-              if (ttl > 300) {
-                env.expire(authKey, 300)
-              }
-            })
-        }
-        return db.users.findOne({ _id: data })
-      })
-      .then((user) => {
-        if (!user) {
-          return Promise.reject(false) // eslint-disable-line prefer-promise-reject-errors
-        }
-        env.set(env.keys.USER_ONLINE + user._id, Date.now())
-        return user
-      })
+    const data = await env.get(authKey)
+    if (!data) {
+      return Promise.reject(false) // eslint-disable-line prefer-promise-reject-errors
+    }
+    if (!noConsume) {
+      env.ttl(authKey)
+        .then((ttl) => {
+          if (ttl > 300) {
+            env.expire(authKey, 300)
+          }
+        })
+    }
+    const user = await db.users.findOne({ _id: data })
+    if (!user) {
+      return Promise.reject(false) // eslint-disable-line prefer-promise-reject-errors
+    }
+    env.set(env.keys.USER_ONLINE + user._id, Date.now())
+    return user
   }
 
-  function checkGame (req) {
-    return db.rooms.findOne({ _id: req.body.room })
-      .then((room) => {
-        if (!room) {
-          return Promise.reject(new Error('invalid room'))
-        }
-        if (/^(W|E)/.test(req.body.room)) {
-          if (room.status === 'out of borders' || (room.openTime && room.openTime > Date.now())) {
-            return Promise.reject(new Error('out of borders'))
-          }
-          return true
-        }
-        return Promise.reject(new Error('not supported'))
-      })
+  async function checkGame (req) {
+    const room = await db.rooms.findOne({ _id: req.body.room })
+    if (!room) {
+      throw new Error('invalid room')
+    }
+    if (/^(W|E)/.test(req.body.room)) {
+      if (room.status === 'out of borders' || (room.openTime && room.openTime > Date.now())) {
+        throw new Error('out of borders')
+      }
+      return true
+    }
+    throw new Error('not supported')
   }
 }

--- a/lib/backend/index.js
+++ b/lib/backend/index.js
@@ -8,11 +8,11 @@ module.exports = function (config) {
   config.cli.on('cliSandbox', (sandbox) => {
     sandbox.mongo = {
       _help: 'mongo.importDB([pathToDB.JSON])',
-      importDB (path) {
-        return Promise.resolve()
-          .then(() => sandbox.system.pauseSimulation())
-          .then(() => config.common.storage.importDB(path))
-          .then(() => sandbox.system.resumeSimulation())
+      async importDB (path) {
+        await sandbox.system.pauseSimulation()
+        const ret = await config.common.storage.importDB(path)
+        await sandbox.system.resumeSimulation()
+        return ret
       }
     }
   })

--- a/lib/common/CollectionWrap.js
+++ b/lib/common/CollectionWrap.js
@@ -1,0 +1,248 @@
+const q = require('q')
+const { ObjectId } = require('mongodb')
+class CollectionWrap {
+  constructor (collection, name) {
+    this.col = collection
+    this.name = name
+  }
+
+  async find (query = {}, filter = {}, opts = {}) {
+    query = this._patchQuery(query)
+    const options = /** @type {any} */ (Object.assign({}, opts))
+    if (filter && Object.keys(filter).length) {
+      options.projection = filter
+    }
+    const res = await this.col.find(query, options).toArray()
+    return q(this._idToKey(res))
+  }
+
+  async findOne (query = {}, filter = {}, opts = {}) {
+    query = this._patchQuery(query)
+    const options = /** @type {any} */ (Object.assign({}, opts))
+    if (filter && Object.keys(filter).length) {
+      options.projection = filter
+    }
+    const res = await this.col.findOne(query, options)
+    return q(this._idToKey(res))
+  }
+
+  async findEx (query = {}, opts = {}) {
+    query = this._patchQuery(query)
+    const cur = this.col.find(query)
+    if (opts.sort) {
+      cur.sort(opts.sort)
+    }
+    if (opts.offset) {
+      cur.offset(opts.offset)
+    }
+    if (opts.limit) {
+      cur.limit(opts.limit)
+    }
+    const res = await cur.toArray()
+    return q(this._idToKey(res))
+  }
+
+  async count (query = {}, opts) {
+    query = this._patchQuery(query)
+    const res = await this.col.countDocuments(query, opts)
+    return q(res)
+  }
+
+  async ensureIndex (fieldOrSpec, opts) {
+    const res = await this.col.ensureIndex(fieldOrSpec, opts)
+    return q(res)
+  }
+
+  async remove (selector, opts) {
+    if (selector && typeof selector === 'object') {
+      selector = this._patchQuery(selector)
+      const res = await this.col.deleteMany(selector, opts)
+      return q(res)
+    }
+    const query = typeof selector === 'undefined' ? {} : { _id: selector }
+    const res = await this.col.deleteOne(query, opts)
+    return q(res)
+  }
+
+  removeWhere (selector, opts) {
+    return this.remove(selector, opts)
+  }
+
+  async insert (doc, opts) {
+    const orig = doc
+    doc = this._patchQuery(doc)
+    if (Array.isArray(doc)) {
+      const { insertedIds } = await this.col.insertMany(doc, opts)
+      orig.forEach((o, i) => {
+        o._id = insertedIds[i]
+      })
+    } else {
+      const { insertedId } = await this.col.insertOne(doc, opts)
+      orig._id = insertedId
+    }
+    return q(orig).then(v => this._idToKey(v))
+  }
+
+  async update (query, doc, opts = {}) {
+    // Allows for Loki's single arg style
+    if (query && !doc) {
+      doc = query
+      query = doc._id
+      delete doc._id
+    }
+    query = typeof query === 'object' ? query : { _id: query }
+    query = this._patchQuery(query)
+    if (opts.multi !== false && doc && Object.keys(doc).find(v => v[0] === '$')) {
+      opts.multi = true
+    }
+    if (doc.$merge) {
+      doc.$set = this._flat(doc.$merge)
+      delete doc.$merge
+    }
+    const mongoOpts = /** @type {any} */ (Object.assign({}, opts))
+    const isMulti = mongoOpts.multi
+    delete mongoOpts.multi
+    const isOperatorUpdate = Object.keys(doc).some(key => key[0] === '$')
+    let res
+    if (isOperatorUpdate) {
+      res = isMulti
+        ? await this.col.updateMany(query, doc, mongoOpts)
+        : await this.col.updateOne(query, doc, mongoOpts)
+    } else if (isMulti) {
+      // MongoDB does not support replacement updates with multi=true.
+      // Keep compatibility by treating this as a field merge.
+      res = await this.col.updateMany(query, { $set: doc }, mongoOpts)
+    } else {
+      res = await this.col.replaceOne(query, doc, mongoOpts)
+    }
+    res.modified = res.modifiedCount
+    res.result = {
+      n: res.matchedCount,
+      nModified: res.modifiedCount,
+      ok: 1
+    }
+    return q(res).then(v => this._idToKey(v))
+  }
+
+  async drop (opts) {
+    try {
+      await this.col.drop(opts)
+    } catch (e) {}
+  }
+
+  clear () {
+    return this.drop
+  }
+
+  by (_id) { // TODO: Where is this used?
+    return this.find({ _id })
+  }
+
+  bulk (bulk, cb) {
+    const batch = this.col.initializeUnorderedBulkOp()
+    try {
+      bulk.forEach(i => {
+        if (i.op === 'insert') {
+          return batch.insert(i.data)
+        }
+        const q = { _id: (i.id && i.id.length === 24) ? new ObjectId(i.id + '') : i.id }
+        if (i.op === 'update') {
+          return batch.find(q).update(i.update)
+        }
+        if (i.op === 'remove') {
+          return batch.find(q).remove()
+        }
+        console.error('UNKNOWN BULK!', i)
+      })
+      return q(batch.execute())
+    } catch (e) {
+      if (!(e instanceof Error)) return
+      if (cb) cb(e.message) // TODO: Check if screeps uses this cb
+      console.error(e)
+      return q.reject(e.message)
+    }
+  }
+
+  _flat (obj, stack = []) {
+    const ret = {}
+    if (typeof obj === 'object' && !Array.isArray(obj)) {
+      Object.entries(obj).forEach(([k, v]) => {
+        Object.assign(ret, this._flat(v, [...stack, k]))
+      })
+    } else if (stack.length) {
+      ret[stack.join('.')] = obj
+    } else {
+      return obj
+    }
+    return ret
+  }
+
+  _keyToId (obj) {
+    const idRegex = /^[a-f0-9]{24}$/
+    if (obj instanceof Array) return obj.map(v => this._keyToId(v))
+    if (obj._id && obj._id.$in) {
+      return Object.assign({}, obj, {
+        _id: {
+          $in: obj._id.$in.map(i => {
+            if (typeof i === 'string' && i.match(idRegex)) {
+              i = new ObjectId(i)
+            }
+            return i
+          })
+        }
+      })
+    }
+    if (typeof obj._id === 'string' && obj._id.match(idRegex)) {
+      return Object.assign({}, obj, { _id: new ObjectId(obj._id) })
+    }
+    return obj
+  }
+
+  _idToKey (obj) {
+    if (obj instanceof Array) return obj.map(v => this._idToKey(v))
+    if (obj && obj._id) {
+      obj._id = obj._id.toString()
+    }
+    return obj
+  }
+
+  _patchLokiOps (query, depth = 5) {
+    if (!depth) return
+    for (const k in query) {
+      const v = query[k]
+      if (k === '$aeq') {
+        delete query[k]
+        query.$eq = v
+      }
+      if (k === '$regex') {
+        // https://github.com/screeps/backend-local/blob/7520c8c7e6a443ad955d25e064dbd151a909d8cb/lib/cronjobs.js#L574
+        // const centralRooms = await db['rooms'].find({_id: {$regex: '^[WE]\d*5[NS]\d*5$'}, status: {$ne: 'out of borders'}});
+        //
+        // regex is not properly escaped resulting in only a subset of possible sectors actually returning
+        if (v === '^[WE]d*5[NS]d*5$') {
+          query.$regex = v.replace(/\]d\*/g, ']\\d*')
+
+          // https://github.com/screeps/backend-local/blob/7520c8c7e6a443ad955d25e064dbd151a909d8cb/lib/cronjobs.js#L393
+          // https://github.com/screeps/backend-local/blob/7520c8c7e6a443ad955d25e064dbd151a909d8cb/lib/strongholds.js#L132
+          //
+          // ignore properly escaped sector regex queries
+        } else if (typeof v === 'string' && v.match(/\^[EW]\d*\\d[NS]\d*\\d\$/g) === null && v.match(/\^\[[EW]{2}\]\\d\*5\[[NS]{2}\]\\d\*5\$/g) === null) {
+          // default regex escape fix for loki regex queries to work with mongo regex queries
+          query.$regex = v.replace(/\\{1,2}/g, '\\\\')
+        } else {
+          query.$regex = v
+        }
+      }
+      if (typeof v === 'object') {
+        this._patchLokiOps(v, depth - 1)
+      }
+    }
+  }
+
+  _patchQuery (query) {
+    query = this._keyToId(query)
+    this._patchLokiOps(query)
+    return query
+  }
+}
+module.exports = CollectionWrap

--- a/lib/common/CollectionWrap.js
+++ b/lib/common/CollectionWrap.js
@@ -1,4 +1,3 @@
-const q = require('q')
 const { ObjectId } = require('mongodb')
 class CollectionWrap {
   constructor (collection, name) {
@@ -13,7 +12,7 @@ class CollectionWrap {
       options.projection = filter
     }
     const res = await this.col.find(query, options).toArray()
-    return q(this._idToKey(res))
+    return this._idToKey(res)
   }
 
   async findOne (query = {}, filter = {}, opts = {}) {
@@ -23,7 +22,7 @@ class CollectionWrap {
       options.projection = filter
     }
     const res = await this.col.findOne(query, options)
-    return q(this._idToKey(res))
+    return this._idToKey(res)
   }
 
   async findEx (query = {}, opts = {}) {
@@ -39,29 +38,29 @@ class CollectionWrap {
       cur.limit(opts.limit)
     }
     const res = await cur.toArray()
-    return q(this._idToKey(res))
+    return this._idToKey(res)
   }
 
   async count (query = {}, opts) {
     query = this._patchQuery(query)
     const res = await this.col.countDocuments(query, opts)
-    return q(res)
+    return res
   }
 
   async ensureIndex (fieldOrSpec, opts) {
     const res = await this.col.ensureIndex(fieldOrSpec, opts)
-    return q(res)
+    return res
   }
 
   async remove (selector, opts) {
     if (selector && typeof selector === 'object') {
       selector = this._patchQuery(selector)
       const res = await this.col.deleteMany(selector, opts)
-      return q(res)
+      return res
     }
     const query = typeof selector === 'undefined' ? {} : { _id: selector }
     const res = await this.col.deleteOne(query, opts)
-    return q(res)
+    return res
   }
 
   removeWhere (selector, opts) {
@@ -80,7 +79,7 @@ class CollectionWrap {
       const { insertedId } = await this.col.insertOne(doc, opts)
       orig._id = insertedId
     }
-    return q(orig).then(v => this._idToKey(v))
+    return this._idToKey(orig)
   }
 
   async update (query, doc, opts = {}) {
@@ -121,7 +120,7 @@ class CollectionWrap {
       nModified: res.modifiedCount,
       ok: 1
     }
-    return q(res).then(v => this._idToKey(v))
+    return this._idToKey(res)
   }
 
   async drop (opts) {
@@ -145,21 +144,23 @@ class CollectionWrap {
         if (i.op === 'insert') {
           return batch.insert(i.data)
         }
-        const q = { _id: (i.id && i.id.length === 24) ? new ObjectId(i.id + '') : i.id }
+        const filter = { _id: (i.id && i.id.length === 24) ? new ObjectId(i.id + '') : i.id }
         if (i.op === 'update') {
-          return batch.find(q).update(i.update)
+          return batch.find(filter).update(i.update)
         }
         if (i.op === 'remove') {
-          return batch.find(q).remove()
+          return batch.find(filter).remove()
         }
         console.error('UNKNOWN BULK!', i)
       })
-      return q(batch.execute())
+      return new Promise((resolve, reject) => {
+        batch.execute((err, result) => (err ? reject(err) : resolve(result)))
+      })
     } catch (e) {
       if (!(e instanceof Error)) return
       if (cb) cb(e.message) // TODO: Check if screeps uses this cb
       console.error(e)
-      return q.reject(e.message)
+      return Promise.reject(e.message)
     }
   }
 

--- a/lib/common/PubSub.js
+++ b/lib/common/PubSub.js
@@ -1,0 +1,44 @@
+const { EventEmitter } = require('events')
+
+class PubSub extends EventEmitter {
+  constructor (pub, sub) {
+    super()
+    this.subscribed = {}
+    this.pub = pub
+    this.sub = sub
+    sub.on('message', (channel, message) => {
+      this.emit(channel, channel, message)
+    })
+    sub.on('pmessage', (pattern, channel, message) => {
+      this.emit(pattern, channel, message)
+    })
+  }
+
+  async publish (channel, data) {
+    this.pub.publish(channel, data)
+  }
+
+  async subscribe (channel, cb) {
+    this.checkSub(channel)
+    const wrapped = (channel, ...args) => cb.apply({ channel }, args)
+    this.on(channel, wrapped)
+  }
+
+  async once (channel, cb) {
+    this.checkSub(channel)
+    const wrapped = (channel, ...args) => cb.apply({ channel }, args)
+    EventEmitter.prototype.once.call(this, channel, wrapped)
+  }
+
+  checkSub (channel) {
+    if (!this.subscribed[channel]) {
+      if (channel.match(/[?*]/)) {
+        this.sub.psubscribe(channel)
+      } else {
+        this.sub.subscribe(channel)
+      }
+      this.subscribed[channel] = true
+    }
+  }
+}
+module.exports = PubSub

--- a/lib/common/_connect.js
+++ b/lib/common/_connect.js
@@ -1,28 +1,39 @@
-const q = require('q')
-const EventEmitter = require('events').EventEmitter
-const { MongoClient, ObjectId } = require('mongodb')
+const { MongoClient } = require('mongodb')
 const Redis = require('redis')
 const fs = require('fs')
 const path = require('path')
+const util = require('util')
+
+const CollectionWrap = require('./CollectionWrap')
+const PubSub = require('./PubSub')
 
 const DATABASE_VERSION = 9
+const LOCK_WAIT_TIMEOUT = 300000
+const LOCK_POLL_INTERVAL = 250
 
 let C
-
+/** @type {Function & { _connected: boolean, db: any, pubsub: any, env: any, queue: any, resetAllData(): void, importDB(path: string): void, upgradeDB(): void }} */
 module.exports = function (config) {
   Object.assign(exports, config.common.storage)
   C = config.common.constants
-  return function storageConnect () {
+  Object.assign(config.common.storage.env.keys, {
+    DATABASE_READY: 'DATABASE_READY'
+  })
+  // Not sure why that one is missing from the list
+  if (!config.common.dbCollections.includes('market.intents')) {
+    config.common.dbCollections.push('market.intents')
+  }
+  return async function storageConnect () {
     if (exports._connected) {
-      return q.when()
+      return
     }
     let uri
-
     if (config.mongo.uri) {
       uri = config.mongo.uri
       delete config.mongo.uri
     } else {
       uri = `mongodb://${config.mongo.host}:${config.mongo.port}/${config.mongo.database}`
+      delete config.mongo.uri
     }
     delete config.mongo.host
     delete config.mongo.port
@@ -31,385 +42,210 @@ module.exports = function (config) {
     const redis = Redis.createClient(config.redis)
     const pub = Redis.createClient(config.redis)
     const sub = Redis.createClient(config.redis)
-    config.redis.clients = { redis, pub, sub }
 
-    const mongo = q.ninvoke(MongoClient, 'connect', uri, Object.assign({ promiseLibrary: Promise, useUnifiedTopology: true }, config.mongo))
-      .then(client => {
-        config.mongo.client = client
-        return client.db()
-      })
-      .then(db => {
-        function wrapCollection (collection, cname) {
-          const wrap = {}
-          function keyToId (obj) {
-            const idRegex = /^[a-f0-9]{24}$/
-            if (obj instanceof Array) return obj.map(keyToId)
-            if (obj._id && obj._id.$in) {
-              return Object.assign({}, obj, {
-                _id: {
-                  $in: obj._id.$in.map(i => {
-                    if (typeof i === 'string' && i.match(idRegex)) {
-                      i = new ObjectId(i)
-                    }
-                    return i
-                  })
-                }
-              })
-            }
-            if (typeof obj._id === 'string' && obj._id.match(idRegex)) {
-              return Object.assign({}, obj, { _id: new ObjectId(obj._id) })
-            }
-            return obj
-          }
-          function idToKey (obj) {
-            if (obj instanceof Array) return obj.map(idToKey)
-            if (obj && obj._id) {
-              obj._id = obj._id.toString()
-            }
-            return obj
-          }
-          function patchLokiOps (query, depth = 5) {
-            if (!depth) return
-            for (const k in query) {
-              const v = query[k]
-              if (k === '$aeq') {
-                delete query[k]
-                query.$eq = v
-              }
-              if (k === '$regex') {
-                // https://github.com/screeps/backend-local/blob/7520c8c7e6a443ad955d25e064dbd151a909d8cb/lib/cronjobs.js#L574
-                // const centralRooms = await db['rooms'].find({_id: {$regex: '^[WE]\d*5[NS]\d*5$'}, status: {$ne: 'out of borders'}});
-                //
-                // regex is not properly escaped resulting in only a subset of possible sectors actually returning
-                if (v === '^[WE]d*5[NS]d*5$') {
-                  query.$regex = v.replace(/\]d\*/g, ']\\d*')
-
-                // https://github.com/screeps/backend-local/blob/7520c8c7e6a443ad955d25e064dbd151a909d8cb/lib/cronjobs.js#L393
-                // https://github.com/screeps/backend-local/blob/7520c8c7e6a443ad955d25e064dbd151a909d8cb/lib/strongholds.js#L132
-                //
-                // ignore properly escaped sector regex queries
-                } else if (typeof v === 'string' && v.match(/\^[EW]\d*\\d[NS]\d*\\d\$/g) === null && v.match(/\^\[[EW]{2}\]\\d\*5\[[NS]{2}\]\\d\*5\$/g) === null) {
-                  // default regex escape fix for loki regex queries to work with mongo regex queries
-                  query.$regex = v.replace(/\\{1,2}/g, '\\\\')
-                } else {
-                  query.$regex = v
-                }
-              }
-              if (typeof v === 'object') {
-                patchLokiOps(v, depth - 1)
-              }
-            }
-          }
-          ;['find', 'findOne', 'findEx', 'by', 'count', 'ensureIndex', 'remove', 'insert', 'update'].forEach(cmethod => {
-            wrap[cmethod] = (...a) => {
-              let method = cmethod
-              try {
-                const orig = a[0]
-                if (typeof a[0] === 'object') {
-                  a[0] = keyToId(a[0])
-                  patchLokiOps(a[0])
-                }
-                if (method === 'update') {
-                  a[2] = a[2] || {}
-                  if (a[2].multi !== false && Object.keys(a[1]).reduce((l, v) => l && v[0] === '$', true)) {
-                    a[2].multi = true
-                  }
-                  if (a[1].$merge) {
-                    const merge = a[1].$merge
-                    delete a[1].$merge
-                    const flat = (obj, stack = []) => {
-                      const ret = {}
-                      if (typeof obj === 'object' && !Array.isArray(obj)) {
-                        Object.entries(obj).forEach(([k, v]) => {
-                          Object.assign(ret, flat(v, [...stack, k]))
-                        })
-                      } else if (stack.length) {
-                        ret[stack.join('.')] = obj
-                      } else {
-                        return obj
-                      }
-                      return ret
-                    }
-                    a[1].$set = flat(merge)
-                  }
-                }
-                const ex = method === 'findEx'
-                if (method === 'find' && a[1]) {
-                  a[1] = { projection: a[1] }
-                }
-                if (ex) {
-                  method = 'find'
-                  a[1].skip = a[1].offset
-                  delete a[1].offset
-                }
-                if (method.slice(0, 6) === 'insert') method = Array.isArray(a[0]) ? 'insertMany' : 'insertOne'
-                let chain = collection[method](...a)
-                if (method === 'insertOne') {
-                  chain = chain.then((n) => {
-                    orig._id = n.insertedId
-                    return orig
-                  })
-                }
-                if (method === 'insertMany') {
-                  chain = chain.then((n) => {
-                    orig.forEach((o, i) => (o._id = n.insertedIds[i]))
-                    return orig
-                  })
-                }
-                if (method === 'update') {
-                  chain = chain.then((n) => Object.assign(n, { modified: n.result.nModified }))
-                }
-                if (method === 'find') {
-                  chain = q.ninvoke(chain, 'toArray')
-                }
-                chain = chain.then(idToKey)
-                  .catch(e => {
-                    console.error('DBERR', e, ex, a)
-                    console.log('DBERR', e.stack)
-                  })
-                return q(chain)
-              } catch (e) {
-                console.error('DBERR', e)
-                console.log('DBERR', e.stack)
-                return q(Promise.reject(e))
-              }
-            }
-          })
-
-          wrap.drop = (...a) => {
-            return q.ninvoke(collection, 'drop', ...a).catch(e => q.resolve())
-          }
-          wrap.clear = wrap.drop
-          wrap.removeWhere = wrap.remove
-          wrap.by = (_id) => wrap.find({ _id })
-          wrap.bulk = function (bulk, cb) {
-            const batch = collection.initializeUnorderedBulkOp()
-            try {
-              bulk.forEach(i => {
-                if (i.op === 'insert') {
-                  if (i.data._id && typeof i.data._id === 'string' && i.data._id.length === 24) {
-                    i.data._id = new ObjectId(i.data._id)
-                  }
-                  return batch.insert(i.data)
-                }
-                const q = { _id: (i.id && i.id.length === 24) ? new ObjectId(i.id + '') : i.id }
-                if (i.op === 'update') {
-                  return batch.find(q).update(i.update)
-                }
-                if (i.op === 'remove') {
-                  return batch.find(q).remove()
-                }
-                console.error('UNKNOWN BULK!', i)
-              })
-              return q.ninvoke(batch, 'execute')
-            } catch (e) {
-              if (cb) cb(e.message)
-              console.error(e)
-              return q.reject(e.message)
-            }
-          }
-          return wrap
+    config.mongo.useUnifiedTopology = true
+    config.mongo.promiseLibrary = Promise
+    config.mongo.validateOptions = true
+    const client = await new MongoClient.connect(uri, config.mongo) // eslint-disable-line new-cap
+    // await client.connect() // Can't do that because that messed up with the options
+    const db = client.db()
+    for (const name of config.common.dbCollections) {
+      const collection = db.collection(name)
+      const indexes = config.common.dbIndexes[name]
+      if (indexes) {
+        for (const k in indexes) {
+          await collection.createIndex({ [k]: indexes[k] })
         }
-        config.common.dbCollections.forEach(i => {
-          const collection = db.collection(i)
-          const indexes = config.common.dbIndexes[i]
-          if (indexes) {
-            collection.createIndexes(Object.entries(indexes).map(([k, v]) => ({ key: { [k]: v } })))
-          }
-          exports.db[i] = wrapCollection(collection, i)
-        })
-        return db
-      })
-      .then(async (db) => {
-        const isInitialized = (await db.listCollections().toArray()).find(coll => coll.name === 'users')
-        // We don't have access to the process type here, but we'll elect 'main' to be the one
-        // in charge of setting up the entire database if it's not done yet.
-        if (process.argv[1].endsWith('engine/dist/main.js')) {
-          if (!isInitialized) {
-            try {
-              console.log('Importing database…')
-              await exports.importDB(path.join(__dirname, '/../../db.original.json'))
-              await exports.upgradeDB()
-            } catch (err) {
-              console.error('An error occured importing existing db, initializing blank server', err)
-              await importFail()
-              console.log('Server initialized. Remember to generate rooms.')
-            }
-          } else {
-            console.log('Database already initialized, skipping import')
-          }
-          // Then we signal the other process that they're good to go
-          exports.env.set('DATABASE_READY', true)
-          return Promise.resolve()
-        } else {
-          console.log('Waiting for database…')
-          return new Promise((resolve) => {
-            const awaiter = () => {
-              const val = exports.env.get('DATABASE_READY')
-              if (val) {
-                return resolve()
-              }
-              setTimeout(awaiter, 100)
-            }
-            awaiter()
-          })
-        }
-      })
-      .then(() => {
-        console.log('Database ready')
-      })
-
-    Object.assign(exports.pubsub, {
-      ee: new EventEmitter(),
-      subscribed: {},
-      publish (channel, data) {
-        pub.publish(channel, data)
-        return q.when()
-      },
-      subscribe (channel, cb) {
-        if (!this.subscribed[channel]) {
-          if (channel.match(/[?*]/)) { sub.psubscribe(channel) } else { sub.subscribe(channel) }
-          this.subscribed[channel] = true
-        }
-        this.ee.on(channel, (channel, ...args) => {
-          cb.apply({ channel }, args)
-        })
-        return q.when()
-      },
-      once (channel, cb) {
-        if (!this.subscribed[channel]) {
-          if (channel.match(/[?*]/)) { sub.psubscribe(channel) } else { sub.subscribe(channel) }
-          this.subscribed[channel] = true
-        }
-        this.ee.once(channel, (channel, ...args) => {
-          cb.apply({ channel }, args)
-        })
-        return q.when()
       }
-    })
-    sub.on('message', (channel, message) => {
-      exports.pubsub.ee.emit(channel, channel, message)
-    })
-    sub.on('pmessage', (pattern, channel, message) => {
-      exports.pubsub.ee.emit(pattern, channel, message)
+      exports.db[name] = new CollectionWrap(collection, name)
+    }
+
+    const pubsub = new PubSub(pub, sub)
+    Object.assign(exports.pubsub, {
+      publish: pubsub.publish.bind(pubsub),
+      subscribe: pubsub.subscribe.bind(pubsub),
+      once: pubsub.once.bind(pubsub)
     })
 
     Object.assign(exports.env, {
-      get: q.nbind(redis.get, redis),
-      mget: q.nbind(redis.mget, redis),
-      sadd: q.nbind(redis.sadd, redis),
-      smembers: q.nbind(redis.smembers, redis),
-      set: q.nbind(redis.set, redis),
-      setex: q.nbind(redis.setex, redis),
-      expire: q.nbind(redis.expire, redis),
-      ttl: q.nbind(redis.ttl, redis),
-      del: q.nbind(redis.del, redis),
-      hmget: q.nbind(redis.hmget, redis),
-      hmset: q.nbind(redis.hmset, redis),
-      hget: q.nbind(redis.hget, redis),
-      hset: q.nbind(redis.hset, redis),
-      hgetall: q.nbind(redis.hgetall, redis),
-      incr: q.nbind(redis.incr, redis),
-      flushall: q.nbind(redis.flushall, redis)
+      _get: util.promisify(redis.get.bind(redis)),
+      mget: util.promisify(redis.mget.bind(redis)),
+      set: util.promisify(redis.set.bind(redis)),
+      setex: util.promisify(redis.setex.bind(redis)),
+      expire: util.promisify(redis.expire.bind(redis)),
+      ttl: util.promisify(redis.ttl.bind(redis)),
+      del: util.promisify(redis.del.bind(redis)),
+      hmget: util.promisify(redis.hmget.bind(redis)),
+      hmset: util.promisify(redis.hmset.bind(redis)),
+      hget: util.promisify(redis.hget.bind(redis)),
+      hset: util.promisify(redis.hset.bind(redis)),
+      hgetall: util.promisify(redis.hgetall.bind(redis)),
+      incr: util.promisify(redis.incr.bind(redis)),
+      flushall: util.promisify(redis.flushall.bind(redis)),
+      sadd: util.promisify(redis.sadd.bind(redis)),
+      smembers: util.promisify(redis.smembers.bind(redis))
     })
 
     exports._connected = true
-    exports.resetAllData = () => q.when() // Temp dummy
+    exports.resetAllData = async () => {} // Temp dummy
 
     Object.assign(exports.queue, require('./queue'))
     exports.queue.wrap(redis, exports.pubsub)
 
-    const oget = exports.env.get
-    exports.env.get = function (...a) {
-      return oget(...a).catch(() => exports.env.hgetall(...a))
+    exports.env.get = async function (...a) {
+      try {
+        return await this._get(...a)
+      } catch (e) {
+        // Hash keys (e.g. roomHistory:*) use HSET; plain env keys use SET. The engine
+        // still calls get() for both — _get rejects with WRONGTYPE when the key is a hash.
+        if (typeof e === 'object' && e !== null && 'code' in e && e.code === 'WRONGTYPE') {
+          return this.hgetall(...a)
+        }
+        throw e
+      }
     }
 
-    exports.resetAllData = () => {
-      return exports.importDB(path.join(__dirname, '/../../db.original.json')).then((r) => q.when(r))
+    const isMainProcess = process.argv[1] && process.argv[1].endsWith('engine/dist/main.js')
+    if (isMainProcess) {
+      const didInit = await withDatabaseLock(exports.env, exports.env.keys.DATABASE_READY, async () => {
+        // Collections can be auto-created by index setup before init runs.
+        // Use actual data presence to detect bootstrap state.
+        const hasUsersData = (await db.collection('users').countDocuments({}, { limit: 1 })) > 0
+        if (!hasUsersData) {
+          try {
+            console.log('Importing database…')
+            await exports.importDB(path.join(__dirname, '/../../db.original.json'))
+          } catch (err) {
+            console.error('An error occured importing existing db, initializing blank server', err)
+            await importFail()
+            console.log('Server initialized. Remember to generate rooms.')
+          }
+        } else {
+          console.log('Database already initialized, skipping import')
+        }
+        await exports.upgradeDB()
+      })
+      if (!didInit) {
+        console.log('Database already initialized, skipping import')
+      }
+    } else {
+      console.log('Waiting for database initialization…')
+      await withDatabaseLock(exports.env, exports.env.keys.DATABASE_READY)
+      console.log('Database initialized, continuing…')
+    }
+
+    exports.resetAllData = async () => {
+      return await exports.importDB(path.join(__dirname, '/../../db.original.json'))
     }
     Object.assign(config.common.storage, exports)
-    return mongo
   }
+}
+
+async function withDatabaseLock (env, keyName, initFn) {
+  if (initFn) {
+    const ready = await env.get(keyName)
+    if (ready) {
+      return false
+    }
+    await initFn()
+    await env.set(keyName, '1')
+    return true
+  }
+  const start = Date.now()
+
+  while (Date.now() - start < LOCK_WAIT_TIMEOUT) {
+    const state = await env.get(keyName)
+    if (state) {
+      return false
+    }
+    await sleep(LOCK_POLL_INTERVAL)
+  }
+
+  throw new Error(`Timed out waiting for database initialization after ${LOCK_WAIT_TIMEOUT}ms`)
+}
+
+function sleep (ms) {
+  return new Promise(resolve => setTimeout(resolve, ms))
 }
 
 exports.importDB = async function importDB (path = './db.json') {
   const { db, env } = exports
+  console.log('Importing DB')
+  await env.set(env.keys.MAIN_LOOP_PAUSED, '1')
   const olddb = JSON.parse(fs.readFileSync(path).toString())
-  const ps = olddb.collections.map(oldcol => {
+  const ps = olddb.collections.map(async oldcol => {
     const name = oldcol.name
-    console.log('Collection', name)
+    console.log(name)
     if (name === 'env') {
-      return env.flushall().then(() => {
-        const p = oldcol.data.map(row => {
-          const ps = []
-          for (const k in row.data) {
-            const v = row.data[k]
-            const type = k.slice(0, k.indexOf(':') + 1)
-            const hashTypes = [env.keys.MEMORY_SEGMENTS, env.keys.ROOM_HISTORY, env.keys.ROOM_EVENT_LOG]
-            if (hashTypes.includes(type)) {
-              for (const kk in v) {
-                ps.push(env.hmset(k, kk, typeof v[kk] === 'object' ? JSON.stringify(v[kk]) : v[kk]))
-              }
-            } else if (k === env.keys.ACTIVE_ROOMS) {
-              ps.push(env.sadd(env.keys.ACTIVE_ROOMS, v))
-            } else {
-              ps.push(env.set(k, typeof v === 'object' ? JSON.stringify(v) : v))
+      await env.flushall()
+      await env.set(env.keys.MAIN_LOOP_PAUSED, '1')
+      const p = oldcol.data.map(async row => {
+        const ps = []
+        row.data[env.keys.MAIN_LOOP_PAUSED] = '1'
+        for (const k in row.data) {
+          const v = row.data[k]
+          const type = k.slice(0, k.indexOf(':') + 1)
+          const hashTypes = [env.keys.MEMORY_SEGMENTS, env.keys.ROOM_HISTORY, env.keys.ROOM_EVENT_LOG]
+          if (hashTypes.indexOf(type) !== -1) {
+            for (const kk in v) {
+              ps.push(env.hmset(k, kk, typeof v[kk] === 'object' ? JSON.stringify(v[kk]) : v[kk]))
             }
+          } else if (k === env.keys.ACTIVE_ROOMS) {
+            ps.push(env.sadd(env.keys.ACTIVE_ROOMS, v))
+          } else {
+            ps.push(env.set(k, typeof v === 'object' ? JSON.stringify(v) : v))
           }
-          return Promise.all(ps)
-        })
-        return Promise.all(p)
+        }
+        await Promise.all(ps)
       })
+      return Promise.all(p)
     } else {
       if (!db[name]) {
-        console.log(`invalid collection in db.json: ${name}`)
-        return Promise.resolve()
+        console.log(`Invalid collection in db.json: ${name}`)
+        return
       }
-      return db[name].drop().then(() => Promise.all(oldcol.data.map(row => {
+      await db[name].drop()
+      await Promise.all(oldcol.data.map(row => {
         delete row.meta
         delete row.$loki
         return db[name].insert(row)
-      })))
+      }))
     }
   })
-
   await Promise.all(ps)
   await db.users.update({ _id: '2' }, { $set: { _id: '2', username: 'Invader', usernameLower: 'invader', cpu: 100, cpuAvailable: 10000, gcl: 13966610.2, active: 0 } }, { upsert: true })
   await db.users.update({ _id: '3' }, { $set: { _id: '3', username: 'Source Keeper', usernameLower: 'source keeper', cpu: 100, cpuAvailable: 10000, gcl: 13966610.2, active: 0 } }, { upsert: true })
-  await db.users.update({ username: 'Screeps' }, { username: 'Screeps', usernameLower: 'screeps', gcl: 0, cpi: 0, active: false, cpuAvailable: 0, badge: { type: 12, color1: '#999999', color2: '#999999', color3: '#999999', flip: false, param: 26 } }, { upsert: true })
+  await db.users.update({ username: 'Screeps' }, { username: 'Screeps', usernameLower: 'screeps', gcl: 0, cpu: 0, active: false, cpuAvailable: 0, badge: { type: 12, color1: '#999999', color2: '#999999', color3: '#999999', flip: false, param: 26 } }, { upsert: true })
   await env.set(env.keys.DATABASE_VERSION, DATABASE_VERSION)
-  return await upgradeDB()
+  await env.set(env.keys.MAIN_LOOP_PAUSED, '0')
+  await env.set(env.keys.DATABASE_VERSION, DATABASE_VERSION)
+  return await exports.upgradeDB()
 }
 
-function importFail () {
+async function importFail () {
   const { db, env } = exports
-  return Promise.all([
-    db.users.insert({ _id: '2', username: 'Invader', usernameLower: 'invader', cpu: 100, cpuAvailable: 10000, gcl: 13966610.2, active: 0 }),
-    db.users.insert({ _id: '3', username: 'Source Keeper', usernameLower: 'source keeper', cpu: 100, cpuAvailable: 10000, gcl: 13966610.2, active: 0 }),
-    db.users.insert({ username: 'Screeps', usernameLower: 'screeps', gcl: 0, cpi: 0, active: false, cpuAvailable: 0, badge: { type: 12, color1: '#999999', color2: '#999999', color3: '#999999', flip: false, param: 26 } }),
+  await Promise.all([
+    db.users.update({ _id: '2' }, { $set: { _id: '2', username: 'Invader', usernameLower: 'invader', cpu: 100, cpuAvailable: 10000, gcl: 13966610.2, active: 0 } }, { upsert: true }),
+    db.users.update({ _id: '3' }, { $set: { _id: '3', username: 'Source Keeper', usernameLower: 'source keeper', cpu: 100, cpuAvailable: 10000, gcl: 13966610.2, active: 0 } }, { upsert: true }),
+    db.users.update({ username: 'Screeps' }, { username: 'Screeps', usernameLower: 'screeps', gcl: 0, cpu: 0, active: false, cpuAvailable: 0, badge: { type: 12, color1: '#999999', color2: '#999999', color3: '#999999', flip: false, param: 26 } }, { upsert: true }),
     env.set('gameTime', 1),
     env.set(env.keys.DATABASE_VERSION, DATABASE_VERSION)
-  ])
+  ].map(v => {
+    v.catch(() => {})
+    return v
+  }))
 }
 
-async function upgradeDB () {
+exports.upgradeDB = async function upgradeDB () {
   const { db, env } = exports
-  const version = parseFloat(await env.get(env.keys.DATABASE_VERSION) || '0')
+  const version = parseInt(await env.get(env.keys.DATABASE_VERSION) || 1)
   if (version === DATABASE_VERSION) return
-  if (version === 0) {
-    console.log('Database not initialized, skipping upgrade check')
-    // await exports.resetAllData()
-    // return upgradeDB()
-    return
-  }
-  console.log(`Database Upgrade needed, current: ${version}, desired: ${DATABASE_VERSION}`)
+  console.log('Database Upgrade needed')
   if (version < 2) {
     console.log('Applying version 2')
-    const ps = []
-    ps.push(db.users.update({ money: { $gt: 0 } }, { $mul: { money: 1000 } }))
-    ps.push(db['market.orders'].update({}, { $mul: { price: 1000 } }))
-    ps.push(db.users.update({ username: 'Screeps' }, { username: 'Screeps', usernameLower: 'screeps', gcl: 0, cpi: 0, active: false, cpuAvailable: 0, badge: { type: 12, color1: '#999999', color2: '#999999', color3: '#999999', flip: false, param: 26 } }, { upsert: true }))
-    await Promise.all(ps)
+    await db.users.update({ money: { $gt: 0 } }, { $mul: { money: 1000 } })
+    await db['market.orders'].update({}, { $mul: { price: 1000 } })
+    await db.users.update({ username: 'Screeps' }, { username: 'Screeps', usernameLower: 'screeps', gcl: 0, cpi: 0, active: false, cpuAvailable: 0, badge: { type: 12, color1: '#999999', color2: '#999999', color3: '#999999', flip: false, param: 26 } }, { upsert: true })
   }
   if (version < 3.1) {
     console.log('Applying version 3.1')
@@ -423,22 +259,22 @@ async function upgradeDB () {
     await db['rooms.objects'].remove({ type: 'powerCreep', ageTime: { $lt: time } })
   }
 
-  if (version < 4) { // Factories update
+  if (version < 4 && DATABASE_VERSION >= 4) { // Factories update
     console.log('Applying version 4')
     const depositTypes = [C.RESOURCE_SILICON, C.RESOURCE_METAL, C.RESOURCE_BIOMASS, C.RESOURCE_MIST]
     const busRooms = await db.rooms.find({ $or: [{ _id: { $regex: /^[WE]\d*0[NS]/ } }, { _id: { $regex: /0$/ } }] })
     const ps = []
     for (const room of busRooms) {
-      const [match, longitude, latitude] = /^[WE](\d+)[NS](\d+)$/.exec(room._id)
+      const [match, longitude, latitude] = /^[WE](\d+)[NS](\d+)$/.exec(room._id) || []
       if (match) {
-        room.depositType = depositTypes[(longitude + latitude) % 4]
-        ps.push(db.rooms.update({ _id: room._id }, room))
+        room.depositType = depositTypes[(Number(longitude) + Number(latitude)) % 4]
+        ps.push(db.rooms.update(room))
       }
     }
     await Promise.all(ps)
   }
 
-  if (version < 5) { // Store update
+  if (version < 5 && DATABASE_VERSION >= 5) { // Store update
     console.log('Applying version 5')
     const ps = []
     const energyOnly = function energyOnly (structure) {
@@ -517,8 +353,7 @@ async function upgradeDB () {
       powerCreeps.forEach(powerCreep => {
         console.log(`powerCreep#${powerCreep._id}`)
         converters.powerCreep(powerCreep)
-        const { _id, ...obj } = powerCreep
-        ps.push(powerCreepsCollection.update({ _id }, obj))
+        ps.push(powerCreepsCollection.update({ _id: powerCreep._id }, powerCreep))
       })
     }
 
@@ -526,8 +361,7 @@ async function upgradeDB () {
     roomObjects.forEach(object => {
       console.log(`${object.type}#${object._id}`)
       converters[object.type](object)
-      const { _id, ...obj } = object
-      ps.push(db['rooms.objects'].update({ _id }, obj))
+      ps.push(db['rooms.objects'].update({ _id: object._id }, object))
     })
 
     const nowTimestamp = new Date().getTime()
@@ -536,13 +370,12 @@ async function upgradeDB () {
       if (!order.createdTimestamp) {
         console.log(`order#${order._id}`)
         order.createdTimestamp = nowTimestamp
-        const { _id, ...obj } = order
-        ps.push(db['market.orders'].update({ _id }, obj))
+        ps.push(db['market.orders'].update({ _id: order._id }, order))
       }
     })
     await Promise.all(ps)
   }
-  if (version < 6) {
+  if (version < 6 && DATABASE_VERSION >= 6) {
     console.log('Applying version 6')
     const ps = []
     const roomObjects = await db['rooms.objects'].find({ type: 'powerBank' })
@@ -556,7 +389,7 @@ async function upgradeDB () {
     await Promise.all(ps)
   }
 
-  if (version < 7) {
+  if (version < 7 && DATABASE_VERSION >= 7) {
     console.log('Applying version 7')
     await db.users.update({ _id: '2' }, {
       $set: {
@@ -574,7 +407,7 @@ async function upgradeDB () {
     })
   }
 
-  if (version < 8) {
+  if (version < 8 && DATABASE_VERSION >= 8) {
     console.log('Applying version 8')
     const gameTime = parseInt(await env.get(env.keys.GAMETIME))
     const roomObjects = await db['rooms.objects'].find({
@@ -584,7 +417,7 @@ async function upgradeDB () {
     })
 
     const ps = roomObjects.map(object => {
-      console.log(`${object.type}#${object._id}: ${JSON.stringify(object.spawning, 0, 2)}`)
+      console.log(`${object.type}#${object._id}: ${JSON.stringify(object.spawning, undefined, 2)}`)
       object.spawning.spawnTime = gameTime + object.spawning.remainingTime
       delete object.spawning.remainingTime
       const { _id, ...obj } = object
@@ -593,7 +426,7 @@ async function upgradeDB () {
     await Promise.all(ps)
   }
 
-  if (version < 9) {
+  if (version < 9 && DATABASE_VERSION >= 9) {
     console.log('Applying version 9')
 
     const ps = []
@@ -621,4 +454,3 @@ async function upgradeDB () {
   await env.set(env.keys.DATABASE_VERSION, '' + DATABASE_VERSION)
   console.log(`Database upgraded to version ${DATABASE_VERSION}`)
 }
-exports.upgradeDB = upgradeDB

--- a/lib/common/_connect.js
+++ b/lib/common/_connect.js
@@ -12,7 +12,7 @@ const LOCK_WAIT_TIMEOUT = 300000
 const LOCK_POLL_INTERVAL = 250
 
 let C
-/** @type {Function & { _connected: boolean, db: any, pubsub: any, env: any, queue: any, resetAllData(): void, importDB(path: string): void, upgradeDB(): void }} */
+/** @type {Function & { _connected: boolean, db: any, pubsub: any, env: any, queue: any, resetAllData(): void, importDB(path: string): void, upgradeDB(): void, importMinimalDB(): void }} */
 module.exports = function (config) {
   Object.assign(exports, config.common.storage)
   C = config.common.constants
@@ -117,7 +117,7 @@ module.exports = function (config) {
             await exports.importDB(path.join(__dirname, '/../../db.original.json'))
           } catch (err) {
             console.error('An error occured importing existing db, initializing blank server', err)
-            await importFail()
+            await exports.importMinimalDB()
             console.log('Server initialized. Remember to generate rooms.')
           }
         } else {
@@ -222,13 +222,13 @@ exports.importDB = async function importDB (path = './db.json') {
   return await exports.upgradeDB()
 }
 
-async function importFail () {
+exports.importMinimalDB = async function importMinimalDB () {
   const { db, env } = exports
   await Promise.all([
     db.users.update({ _id: '2' }, { $set: { _id: '2', username: 'Invader', usernameLower: 'invader', cpu: 100, cpuAvailable: 10000, gcl: 13966610.2, active: 0 } }, { upsert: true }),
     db.users.update({ _id: '3' }, { $set: { _id: '3', username: 'Source Keeper', usernameLower: 'source keeper', cpu: 100, cpuAvailable: 10000, gcl: 13966610.2, active: 0 } }, { upsert: true }),
     db.users.update({ username: 'Screeps' }, { username: 'Screeps', usernameLower: 'screeps', gcl: 0, cpu: 0, active: false, cpuAvailable: 0, badge: { type: 12, color1: '#999999', color2: '#999999', color3: '#999999', flip: false, param: 26 } }, { upsert: true }),
-    env.set('gameTime', 1),
+    env.set(env.keys.GAMETIME, 1),
     env.set(env.keys.DATABASE_VERSION, DATABASE_VERSION)
   ].map(v => {
     v.catch(() => {})

--- a/lib/common/queue.js
+++ b/lib/common/queue.js
@@ -1,4 +1,4 @@
-const q = require('q')
+const util = require('util')
 
 const queues = new Proxy({
   init (name) {
@@ -27,7 +27,8 @@ const queues = new Proxy({
 })
 
 function wrap (redis, name) {
-  return (...a) => q.ninvoke(redis, name, ...a)
+  const fn = util.promisify(redis[name].bind(redis))
+  return (...a) => fn(...a)
 }
 
 let pubsub

--- a/lib/common/queue.js
+++ b/lib/common/queue.js
@@ -9,9 +9,9 @@ const queues = new Proxy({
         emit (channel) {
           return pubsub.publish(`queue_${name}_${channel}`, '1')
         },
-        once (channel, cb) {
+        once (channel, callb) {
           return pubsub.once(`queue_${name}_${channel}`, (...a) => {
-            cb(...a) // eslint-disable-line
+            callb(...a)
           })
         }
       }
@@ -40,104 +40,54 @@ module.exports = {
     redis.funcs.forEach(f => (redis[f] = wrap(nredis, f)))
     pubsub = npubsub
   },
-  fetch (name, cb) {
-    const defer = q.defer()
-    try {
-      const check = function () {
-        redis.rpoplpush(queues[name].pending, queues[name].processing)
-          .then(item => {
-            if (!item || item === 'nil') {
-              setTimeout(check, 10)
-              return
-            }
-            defer.resolve(item)
-          }).catch(err => console.error('fetch', err))
+  async fetch (name, cb) {
+    while (true) {
+      const item = await redis.rpoplpush(queues[name].pending, queues[name].processing)
+      if (!item || item === 'nil') {
+        await sleep(10)
+        continue
       }
-      check()
-    } catch (e) {
-      defer.reject(e.message)
-      console.error(e)
+      return item
     }
-    return defer.promise
   },
-  markDone (name, id, cb) {
-    const defer = q.defer()
-    try {
-      redis.lrem(queues[name].processing, 0, id)
-      queues[name].emitter.emit('done')
-      defer.resolve(true)
-    } catch (e) {
-      defer.reject(e.message)
-      console.error(e)
-    }
-    return defer.promise
+  async markDone (name, id, cb) {
+    await redis.lrem(queues[name].processing, 0, id)
+    queues[name].emitter.emit('done')
+    return true
   },
-  add (name, id, cb) {
-    const defer = q.defer()
-    try {
-      redis.lpush(queues[name].pending, id)
-      queues[name].emitter.emit('add')
-      defer.resolve(true)
-    } catch (e) {
-      defer.reject(e.message)
-      console.error(e)
-    }
-    return defer.promise
+  async add (name, id, cb) {
+    await redis.lpush(queues[name].pending, id)
+    queues[name].emitter.emit('add')
   },
-  addMulti (name, array, cb) {
-    const defer = q.defer()
-    try {
-      redis.lpush(queues[name].pending, ...array)
-      queues[name].emitter.emit('add')
-      defer.resolve(true)
-    } catch (e) {
-      defer.reject(e.message)
-      console.error(e)
-    }
-    return defer.promise
+  async addMulti (name, array, cb) {
+    await redis.lpush(queues[name].pending, ...array)
+    queues[name].emitter.emit('add')
+    return true
   },
-  whenAllDone (name, cb) {
-    const defer = q.defer()
-    try {
-      const check = function (reset) {
-        q.all([
-          redis.llen(queues[name].pending),
-          redis.llen(queues[name].processing)
-        ]).then(cnts => {
-          if (cnts[0] + cnts[1]) {
-            // queues[name].emitter.once('done', check);
-            setTimeout(check, 10)
-            return
-          }
-          pubsub.publish('queueDone:' + name, '1')
-          defer.resolve(true)
-        })
-      }
-      check()
-    } catch (e) {
-      defer.reject(e.message)
-      console.error(e)
-    }
-    return defer.promise
-  },
-  reset (name, cb) {
-    const defer = q.defer()
-    try {
-      q.all([
+  async whenAllDone (name, cb) {
+    while (true) {
+      const cnts = await Promise.all([
         redis.llen(queues[name].pending),
         redis.llen(queues[name].processing)
-      ]).then((ret) => {
-      }).then(() => q.all([
-        redis.del(queues[name].pending),
-        redis.del(queues[name].processing)
-      ])).then((ret) => {
-        queues[name].emitter.emit('done', true)
-        defer.resolve(true)
-      })
-    } catch (e) {
-      defer.reject(e.message)
-      console.error(e)
+      ])
+      if (cnts[0] + cnts[1]) {
+        await sleep(10)
+        continue
+      }
+      pubsub.publish('queueDone:' + name, '1')
+      return true
     }
-    return defer.promise
+  },
+  async reset (name, cb) {
+    await Promise.all([
+      redis.del(queues[name].pending),
+      redis.del(queues[name].processing)
+    ])
+    queues[name].emitter.emit('done', true)
+    return true
   }
+}
+
+function sleep (ms) {
+  return new Promise(resolve => setTimeout(resolve, ms))
 }

--- a/lib/engine/driver.js
+++ b/lib/engine/driver.js
@@ -1,8 +1,7 @@
-const q = require('q')
 const _ = require('lodash')
 
 function checkNotificationOnline (userId) {
-  return q.when(true) // TODO
+  return Promise.resolve() // TODO
 }
 
 module.exports = function (config) {
@@ -15,42 +14,38 @@ module.exports = function (config) {
       const activeRooms = new Set()
       for (const room in intents) {
         if (room === 'notify') {
-          updates.push(checkNotificationOnline(userId)
-            .then(() => {
-              if (intents.notify.length > 20) {
-                intents.notify = _.take(intents.notify, 20)
+          updates.push(async () => {
+            await checkNotificationOnline(userId)
+            if (intents.notify.length > 20) {
+              intents.notify = _.take(intents.notify, 20)
+            }
+
+            for (const i of intents.notify) {
+              if (i.groupInterval < 0) {
+                i.groupInterval = 0
               }
+              if (i.groupInterval > 1440) {
+                i.groupInterval = 1440
+              }
+              i.groupInterval *= 60 * 1000
+              i.groupInterval = Math.floor(i.groupInterval)
+              const date = i.groupInterval ? new Date(Math.ceil(new Date().getTime() / i.groupInterval) * i.groupInterval) : new Date()
 
-              const promises = [q.when()]
+              const message = ('' + i.message).substring(0, 500)
 
-              intents.notify.forEach((i) => {
-                if (i.groupInterval < 0) {
-                  i.groupInterval = 0
-                }
-                if (i.groupInterval > 1440) {
-                  i.groupInterval = 1440
-                }
-                i.groupInterval *= 60 * 1000
-                i.groupInterval = Math.floor(i.groupInterval)
-                const date = i.groupInterval ? new Date(Math.ceil(new Date().getTime() / i.groupInterval) * i.groupInterval) : new Date()
-
-                const message = ('' + i.message).substring(0, 500)
-
-                promises.push(db['users.notifications'].update({
-                  $and: [
-                    { user: userId },
-                    { message },
-                    { date: date.getTime() },
-                    { type: 'msg' }
-                  ]
-                }, {
-                  $inc: { count: 1 }
-                },
-                { upsert: true }))
-              })
-
-              return q.all(promises)
-            }))
+              await db['users.notifications'].update({
+                $and: [
+                  { user: userId },
+                  { message },
+                  { date: date.getTime() },
+                  { type: 'msg' }
+                ]
+              }, {
+                $inc: { count: 1 }
+              },
+              { upsert: true })
+            }
+          })
           continue
         }
 
@@ -68,39 +63,37 @@ module.exports = function (config) {
       if (activeRooms.size > 0) {
         updates.push(driver.activateRoom(Array.from(activeRooms)))
       }
-      return q.all(updates)
+      return Promise.all(updates)
     },
     clearRoomIntents (roomId) {
       return env.del(env.keys.ROOM_INTENTS + roomId)
     },
-    getRoomIntents (roomId) {
-      return env.hgetall(env.keys.ROOM_INTENTS + roomId)
-        .then(data => {
-          const users = {}
-          const manual = {}
-          if (!data) {
-            return { users }
-          }
-          _.each(data, (intents, userId) => {
-            intents = JSON.parse(intents)
-            const [, id] = userId.match(/^(.*)\.manual$/) || []
-            if (id) {
-              manual[id] = { objectsManual: intents }
-            } else {
-              users[userId] = { objects: intents }
-            }
-          })
-          _.each(manual, (data, userId) => {
-            users[userId] = users[userId] || {}
-            users[userId].objectsManual = data.objectsManual
-          })
-          return { users }
-        })
+    async getRoomIntents (roomId) {
+      const data = await env.hgetall(env.keys.ROOM_INTENTS + roomId)
+      /** @type {{ objects?: any }} */
+      const users = {}
+      /** @type {{ objectsManual?: any }} */
+      const manual = {}
+      if (!data) {
+        return { users }
+      }
+      _.each(data, (intents, userId) => {
+        intents = JSON.parse(intents)
+        const [, id] = userId.match(/^(.*)\.manual$/) || []
+        if (id) {
+          manual[id] = { objectsManual: intents }
+        } else {
+          users[userId] = { objects: intents }
+        }
+      })
+      _.each(manual, (data, userId) => {
+        users[userId] = users[userId] || {}
+        users[userId].objectsManual = data.objectsManual
+      })
+      return { users }
     },
     incrementGameTime () {
       return env.incr(env.keys.GAMETIME)
-      // common.getGametime()
-      //  .then(gameTime => env.set(env.keys.GAMETIME, gameTime + 1).then(() => gameTime + 1))
     }
   })
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,4 +2,22 @@ module.exports = function (config) {
   require('./common')(config) // This is for adding stuff ALL the mods/modules will see
   if (config.backend) require('./backend')(config) // API and CLI stuff
   if (config.engine) require('./engine')(config) // Engine stuff
+  if (config.storage) {
+    config.storage.socketListener = () => {}
+    config.storage.loadDb = async () => {
+      // Will never return. This is solely to disable the process while staying running.
+      if (process.send) {
+        process.send('storageLaunched')
+      }
+      console.log('screepsmod-mongo has disabled builtin storage')
+      while (true) {
+        // Just to keep the process 'alive' (prevents relaunching each time it dies)
+        await sleep(100000)
+      }
+    }
+  }
+}
+
+function sleep (ms) {
+  return new Promise(resolve => setTimeout(resolve, ms))
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,7 @@ module.exports = function (config) {
   if (config.backend) require('./backend')(config) // API and CLI stuff
   if (config.engine) require('./engine')(config) // Engine stuff
   if (config.storage) {
+    mockLokiStorageDb(config.storage)
     config.storage.socketListener = () => {}
     config.storage.loadDb = async () => {
       // Will never return. This is solely to disable the process while staying running.
@@ -20,4 +21,41 @@ module.exports = function (config) {
 
 function sleep (ms) {
   return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+function mockLokiStorageDb (storage) {
+  // There's a stray `setInterval(function envCleanExpired()` in
+  // @screeps/storage/lib/db.js that causes a crash when it hits,
+  // since we're not using the real storage db. Mock enough of it
+  // that it can run and do nothing.
+  if (typeof storage.getDb !== 'function' || typeof storage.loadDb !== 'function') {
+    return
+  }
+  const originalGetDb = storage.getDb
+  const originalLoadDb = storage.loadDb
+  storage.getDb = makeLegacyDbMock
+  originalLoadDb()
+    .catch(err => {
+      console.warn('[screepsmod-mongo] Failed to prime legacy storage DB shim:', err && err.message ? err.message : err)
+    })
+    .finally(() => {
+      storage.getDb = originalGetDb
+    })
+}
+
+function makeLegacyDbMock () {
+  const envCollection = {
+    get: () => undefined,
+    update: () => {},
+    insert: () => {}
+  }
+  return {
+    loadDatabase: (_opts, cb) => cb(null),
+    getCollection: (name) => {
+      if (name === 'env') {
+        return envCollection
+      }
+      return null
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screepsmod-mongo",
-  "version": "2.13.0",
+  "version": "3.0.0-beta.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -24,8 +24,6 @@
     "ini": "^1.3.8",
     "lodash": "^4.17.21",
     "mongodb": "^3.7.4",
-    "q": "^1.5.1",
-    "q-json-response": "^0.1.3",
     "redis": "^3.1.2"
   },
   "repository": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,12 +23,6 @@ importers:
       mongodb:
         specifier: ^3.7.4
         version: 3.7.4
-      q:
-        specifier: ^1.5.1
-        version: 1.5.1
-      q-json-response:
-        specifier: ^0.1.3
-        version: 0.1.3
       redis:
         specifier: ^3.1.2
         version: 3.1.2
@@ -856,9 +850,6 @@ packages:
   lodash.padstart@4.6.1:
     resolution: {integrity: sha512-sW73O6S8+Tg66eY56DBk85aQzzUJDtpoXFBgELMd5P/SotAguo+1kYO6RuYgXxA4HJH3LFTFPASX6ET6bjfriw==}
 
-  lodash@3.10.1:
-    resolution: {integrity: sha512-9mDDwqVIma6OZX79ZlDACZl8sBm0TEnkf99zV3iMA4GzkIT/9hiqP5mY0HoT1iNLCrKc/R1HByV+yJfRWVJryQ==}
-
   lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
 
@@ -1162,17 +1153,6 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
-
-  q-json-response@0.1.3:
-    resolution: {integrity: sha512-v3SbbBCZw1z3ASTJU/cA7kTnevqVrDkiGD1uKm33kZwOuji2QvOqF+kE445h6lOggBclN/D260tlEswiDLI2dw==}
-
-  q@1.5.1:
-    resolution: {integrity: sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==}
-    engines: {node: '>=0.6.0', teleport: '>=0.2.0'}
-    deprecated: |-
-      You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.
-
-      (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
 
   qs@6.13.0:
     resolution: {integrity: sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==}
@@ -2516,8 +2496,6 @@ snapshots:
 
   lodash.padstart@4.6.1: {}
 
-  lodash@3.10.1: {}
-
   lodash@4.17.21: {}
 
   loose-envify@1.4.0:
@@ -2721,13 +2699,6 @@ snapshots:
       semver: 4.3.6
 
   punycode@2.3.1: {}
-
-  q-json-response@0.1.3:
-    dependencies:
-      lodash: 3.10.1
-      q: 1.5.1
-
-  q@1.5.1: {}
 
   qs@6.13.0:
     dependencies:


### PR DESCRIPTION
This makes the server run against MongoDB v8.2.7 and Redis v8.6.3.

Also gets rid of `q` entirely in favor of vanilla promises and side-steps a [silly issue](https://github.com/screeps/storage/pull/7) in @screeps/storage. The minimal db setup function is exposed so admin-utils' importMap can make use of it instead of carrying its own version of that setup.